### PR TITLE
Forward additional event argument also to state event listeners

### DIFF
--- a/lib/StateMachine.js
+++ b/lib/StateMachine.js
@@ -116,7 +116,7 @@ class StateMachine extends EventEmitter {
           // Update internal state
           this._state = row.to
           // Notify all listeners for a new state
-          this.emit('state', this._state)
+          this.emit('state', this._state, ...args)
           // Await the on<event> and on<state> internal overrides
           if (this[onEv]) await this[onEv](...args)
           if (this[onTo]) await this[onTo](...args)

--- a/test/StateMachineTest.js
+++ b/test/StateMachineTest.js
@@ -9,6 +9,7 @@ describe('A TestClass which extends StateMachine', () => {
   let testClass
   let invalidTransition = {}
   let seenStates = []
+  const seenReasonAndStates = new Map()
 
   it('should properly instantiate', () => {
     testClass = new TestClass()
@@ -17,7 +18,10 @@ describe('A TestClass which extends StateMachine', () => {
 
   describe('A TestClass instance', () => {
     it('should allow to register "onStateChange()" callback', () => {
-      testClass.on('state', state => seenStates.push(state))
+      testClass.on('state', (state, reason) => {
+        seenStates.push(state)
+        seenReasonAndStates.set(state, reason)
+      })
     })
     it('should allow to register "onInvalidTransition()" callback', () => {
       testClass.on('invalidTransition', (event, state) => {
@@ -46,6 +50,9 @@ describe('A TestClass which extends StateMachine', () => {
     })
     it('should have forwarded the payload', () => {
       assert.equal(testClass.bravoParam, 'fakePayload')
+      assert.equal(seenReasonAndStates.get('AlmostBravo'), 'fakePayload') // forwarded to the on(state) listener
+      assert(seenReasonAndStates.has('Bravo'))
+      assert.isUndefined(seenReasonAndStates.get('Bravo')) // but not forwarded to here
     })
     it('should have reported about to state changes through the callback', () => {
       assert.deepEqual(['AlmostBravo', 'Bravo'], seenStates)


### PR DESCRIPTION
# Description

The event function `toBravo()` and such may receive additional optional arguments already. Those are being forwarded to the `onAlmostBravo` target event functions already. However, those additional arguments are left out when emitting the `'state'` event notification but there's no obvious reason why they shouldn't be forwarded to those, too. Hence this PR adds this to the `'state'` event, too.

## How has this been tested?

Unittest has been added to check not only for the payload forwarded to `onAlmostBravo` but also to the state event.
