### PR TITLE
Switch ordering between life-cycle functions and state event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - xx xx 2021
+
+- Change call order between `on<event>` life-cycle functions and 'state' event:
+  First call life-cycle functions, then state
+
 ## [2.2.0] - 27 Aug 2021
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ myClient.connect()
 
 In the body of your class you can define life-cycle functions `on<event>` and
 `on<state>`, which are automatically called and can be used to trigger
-further events:
+further events. Note: the life-cycle functions `on<event>` and `on<state>` will
+be called *before* the 'state' event will be emitted. The life-cycle functions
+can be defined as follows:
 
 ```javascript
 const StateMachine = require('fsm-async')

--- a/lib/StateMachine.js
+++ b/lib/StateMachine.js
@@ -115,11 +115,11 @@ class StateMachine extends EventEmitter {
         if (this._allowedStates.get(row.ev).includes(this._state) || row.from === '*') {
           // Update internal state
           this._state = row.to
-          // Notify all listeners for a new state
-          this.emit('state', this._state, ...args)
           // Await the on<event> and on<state> internal overrides
           if (this[onEv]) await this[onEv](...args)
           if (this[onTo]) await this[onTo](...args)
+          // Notify all listeners for a new state (but only *after* the internal functions!)
+          this.emit('state', this._state, ...args)
         } else {
           // Notify about invalid transition
           this.emit('invalidTransition', row.ev, this._state)


### PR DESCRIPTION
# Description

The ordering in the transition functions previous was that first the 'state' event was emitted (to the outside), secondly the class-internal on<event> life-cycle function was called. At the cybus software, that turned out to be the root cause of some problem, because there may be events that should immediately be followed by other class-internal action, even before any outside event listener is notified about the state change. In the previous ordering that was impossible. By switching this to first call the class-internal life-cycle functions and *then* emit the event, it ensures that the class stays in ownership of its own state and its own state interpretation.

## How has this been tested?

We changed this to fix some remaining bug in the cybus software in CYB-3488 (2022-03-07, appearing in release 1.0.78), and it has been in active use since then, so I would conclude that it works fine.
